### PR TITLE
In server view, panel Power Controls title modified to Controls

### DIFF
--- a/resources/assets/lang/en/server.json
+++ b/resources/assets/lang/en/server.json
@@ -56,7 +56,7 @@
     "SRV_ID": "Server ID"
   },
   "ipmi": {
-    "TITLE": "Power Controls",
+    "TITLE": "Controls",
     "NOT_ENABLED": "This server is not IPMI-ready",
     "ADDRESS": "IPMI IP Address",
     "BMC": {


### PR DESCRIPTION
It is modified the panel title on the server edition to 'Controls' instead of 'Powers Controls.

Before
![client-before](https://github.com/synergycp/scp-theme-client/assets/12122895/42abd880-b1bd-4a53-90c3-5f9cf805dc17)
After
![client-after](https://github.com/synergycp/scp-theme-client/assets/12122895/52cc8a3d-fd40-4225-85bb-3ea41dcfd010)
